### PR TITLE
add wake_n()

### DIFF
--- a/src/freebsd.rs
+++ b/src/freebsd.rs
@@ -28,6 +28,19 @@ pub fn wake_one(ptr: *const AtomicU32) {
 }
 
 #[inline]
+pub fn wake_n(ptr: *const AtomicU32, wake_count: u32) {
+    unsafe {
+        libc::_umtx_op(
+            ptr as *mut libc::c_void,
+            libc::UMTX_OP_WAKE_PRIVATE,
+            wake_count as libc::c_ulong,
+            core::ptr::null_mut(),
+            core::ptr::null_mut(),
+        );
+    };
+}
+
+#[inline]
 pub fn wake_all(ptr: *const AtomicU32) {
     unsafe {
         libc::_umtx_op(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,27 @@ pub fn wake_one(atomic: *const AtomicU32) {
     platform::wake_one(atomic);
 }
 
+/// Wake up to n threads that are waiting on this atomic.
+///
+/// It's okay if the pointer dangles or is null.
+///
+/// ______________________
+/// **Remarks:**
+///
+/// On platforms where this is not _natively_ supported by the kernel,
+/// it is emulated with a loop to wake_one. Don't use excessively
+/// large `wake_count` if you're targeting Windows or OSX, or this
+/// loop will be too costly.
+///
+/// This is an optimization for small `wake_count`s, like 2-10, on
+/// linux and freebsd.
+/// If you're unsure, just use `wake_all()` or `wake_one()` which are
+/// universally supported.
+#[inline]
+pub fn wake_n(atomic: *const AtomicU32, wake_count: u32) {
+    platform::wake_n(atomic, wake_count);
+}
+
 /// Wake all threads that are waiting on this atomic.
 ///
 /// It's okay if the pointer dangles or is null.

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -26,6 +26,18 @@ pub fn wake_one(ptr: *const AtomicU32) {
 }
 
 #[inline]
+pub fn wake_n(ptr: *const AtomicU32, wake_count: u32) {
+    unsafe {
+        libc::syscall(
+            libc::SYS_futex,
+            ptr,
+            libc::FUTEX_WAKE | libc::FUTEX_PRIVATE_FLAG,
+            wake_count as i32,
+        );
+    };
+}
+
+#[inline]
 pub fn wake_all(ptr: *const AtomicU32) {
     unsafe {
         libc::syscall(

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -65,6 +65,13 @@ pub fn wake_one(ptr: *const AtomicU32) {
 }
 
 #[inline]
+pub fn wake_n(ptr: *const AtomicU32, wake_count: u32) {
+    for _ in 0..wake_count {
+        wake_one(ptr);
+    }
+}
+
+#[inline]
 pub fn wake_all(ptr: *const AtomicU32) {
     unsafe { __cxx_atomic_notify_all(ptr.cast()) };
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -17,6 +17,13 @@ pub fn wake_one(ptr: *const AtomicU32) {
 }
 
 #[inline]
+pub fn wake_n(ptr: *const AtomicU32, wake_count: u32) {
+    for _ in 0..wake_count {
+        wake_one(ptr);
+    }
+}
+
+#[inline]
 pub fn wake_all(ptr: *const AtomicU32) {
     unsafe { WakeByAddressAll(ptr.cast()) };
 }


### PR DESCRIPTION
A small optimization for linux and bsd, where you would have written multiple wake_one()s in a row or put them in a loop. `wake_n` should be no worse than doing that on macos/windows, while being slightly better on linux.

I'm using this in [k-lock](https://docs.rs/k-lock/latest/k_lock/) for a very small contended performance increase.

This is the impact of replacing `wake_one(); wake_one();`  with `wake_n(2)` in the above library with 32 threads contending:
![image](https://github.com/user-attachments/assets/d9ac4ea8-74c2-4f4d-90a2-d9b4861a7dcb)

I don't have means of testing the platforms other than linux; but hopefully the code is simple enough that I got it right 😄 