### PR TITLE
Bump windows-sys to 0.59.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ categories = ["concurrency", "os", "no-std"]
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.42.0", features = ["Win32_System_Threading", "Win32_Foundation", "Win32_System_WindowsProgramming"] }
+windows-sys = { version = "0.59.0", features = ["Win32_System_Threading", "Win32_Foundation", "Win32_System_WindowsProgramming"] }


### PR DESCRIPTION
To reduce copies of the library in Cargo.lock projects using `atomic-wait`.